### PR TITLE
added Polyfill for Math.log2 for use with ES5

### DIFF
--- a/lib/expb.js
+++ b/lib/expb.js
@@ -1,3 +1,7 @@
+Math.log2 = Math.log2 || function(x) {
+  return Math.log(x) / Math.LN2;
+};
+
 const MaxLog2 = Math.log2(Number.MAX_VALUE) - 1;
 
 function netErrorChecker(err) {


### PR DESCRIPTION
Makes sure that the call to Math.log2 will work with node 10.X or lower by creating a polyfill for the method.
